### PR TITLE
Only show first active care plan and goals/tasks for that plan

### DIFF
--- a/capable/CarePlan.js
+++ b/capable/CarePlan.js
@@ -80,7 +80,10 @@ class CarePlan extends DataWrapper {
             }),
         ]);
       } else throw "Care plan template not found.";
-    } else carePlan = new CarePlan(carePlans[0]);
+    } else {
+      const activeCarePlans = carePlans.filter((carePlan) => carePlan.status == "active");
+      carePlan = new CarePlan(activeCarePlans[0]);
+    }
 
     return carePlan;
   }

--- a/capable/CarePlan.js
+++ b/capable/CarePlan.js
@@ -3,7 +3,7 @@ import Logger from "js-logger";
 import { CapableClient, GET, POST } from "./api";
 import { CarePlanTemplate } from "./CarePlanTemplate";
 import { DataWrapper } from "./DataWrapper";
-import { today } from "../helpers/dayjs";
+import { dayjs, today } from "../helpers/dayjs";
 import { Goal } from "./Goal";
 import { GoalTemplate } from "./GoalTemplate";
 import { Task } from "./Task";
@@ -81,7 +81,14 @@ class CarePlan extends DataWrapper {
         ]);
       } else throw "Care plan template not found.";
     } else {
-      const activeCarePlans = carePlans.filter((carePlan) => carePlan.status == "active");
+      const activeCarePlans = carePlans
+        .filter((carePlan) => carePlan.status == "active")
+        .sort((a, b) => {
+          const dateA = dayjs.utc(a.created_at);
+          const dateB = dayjs.utc(b.created_at);
+          return dateB.diff(dateA);
+        });
+      if (activeCarePlans.length == 0) throw "No active care plans found.";
       carePlan = new CarePlan(activeCarePlans[0]);
     }
 

--- a/screens/Home.js
+++ b/screens/Home.js
@@ -327,6 +327,8 @@ const Home = ({ navigation }) => {
   const [carePlan, setCarePlan] = useState(new CarePlan());
   const [goals, setGoals] = useState([]);
   const [tasks, setTasks] = useState([]);
+  const [activeGoals, setActiveGoals] = useState([]);
+  const [activeTasks, setActiveTasks] = useState([]);
   const [selectedWeek, setSelectedWeek] = useState(1);
   const isFocused = useIsFocused();
 
@@ -400,6 +402,16 @@ const Home = ({ navigation }) => {
     });
   }, [isFocused]);
 
+  useEffect(() => {
+    const activeGoals = goals.filter((goal) => goal.care_plan_id == carePlan.id);
+    setActiveGoals(activeGoals);
+  }, [carePlan, goals]);
+
+  useEffect(() => {
+    const activeTasks = tasks.filter((task) => task.care_plan_id == carePlan.id);
+    setActiveTasks(activeTasks);
+  }, [carePlan, tasks]);
+
   const toggleTaskStatus = (task) => {
     task.setStatus(Number(!task.isCompleted)).then((updatedTask) => {
       setTasks(tasks.map((task) => (task.id == updatedTask.id ? updatedTask : task)));
@@ -415,8 +427,8 @@ const Home = ({ navigation }) => {
         onSelectWeek={setSelectedWeek}
         navigation={navigation}
       />
-      <GoalsList goals={goals} week={selectedWeek} />
-      <TaskList tasks={tasks} week={selectedWeek} toggleTaskStatus={toggleTaskStatus} />
+      <GoalsList goals={activeGoals} week={selectedWeek} />
+      <TaskList tasks={activeTasks} week={selectedWeek} toggleTaskStatus={toggleTaskStatus} />
     </AppView>
   );
 };


### PR DESCRIPTION
### Ticket or Explanation for PR

[sc-2152]

I created separate state hooks (`activeGoals` and `activeTasks`) so that the goals and tasks can still be fetched async while fetching the careplan

### Please describe how the PR was tested

Web and mobile iOS

### PR merging checklist
Please add any other relevant checkbox items here.

- [x] I linked a Shortcut ticket to my PR (if applicable)
- [x] I pulled in the latest changes from `dev` and there's no conflicts
- [x] I corrected all linting/formatting issues
- [x] I tested my changes in a mobile emulator 
- [ ] My PR has been approved by at least one reviewer

